### PR TITLE
Fix problem: use offline.py and Llama-2-7b-hf in a local directory

### DIFF
--- a/distserve/downloader/converter.py
+++ b/distserve/downloader/converter.py
@@ -29,6 +29,9 @@ import argparse
 from glob import glob
 from torch import nn
 from typing import Callable, Dict, Optional, Tuple
+from distserve.logger import init_logger
+
+logger = init_logger(__name__)
 
 #######################
 #    Preprocessors    #
@@ -417,15 +420,17 @@ def convert_weights(
     # Load the state dict (tensor_dict)
     # If the whole model is saved in a single file, then load the state dict directly
     # otherwise, load them separately and merge them into a single state dict
-    input_files = glob(input)
-    if len(input_files) == 0:
+    bin_files = glob(os.path.join(input, '*.bin'))
+    #logger.info(f"Find bin files : {bin_files}.") 
+    #input_files = glob(input)
+    if len(bin_files) == 0:
         ValueError(f"Input {input} does not match any files")
         print(f"Input {input} does not match any files")
         exit(1)
     
     # Load file(s)
     state_dict = {}
-    for file in input_files:
+    for file in bin_files:
         print(f"Loading {file}")
         state_dict.update(torch.load(file, torch.device("cpu")))
 

--- a/distserve/downloader/downloader.py
+++ b/distserve/downloader/downloader.py
@@ -110,11 +110,6 @@ def download_and_convert_weights(model_config: ModelConfig) -> str:
         
         # if the user provides a local path
         is_local = os.path.isdir(model_name_or_path)
-        if is_local:
-            if model_name_or_path[-1] == '/':
-                return model_name_or_path
-            else:
-                return model_name_or_path + '/'
         
         # if the model weights have already been downloaded and converted before
         cache_dir = DISTSERVE_CACHE
@@ -127,7 +122,11 @@ def download_and_convert_weights(model_config: ModelConfig) -> str:
             return storage_folder
         
         # download and convert model weights
-        hf_files = prepare_hf_model_weigths(model_name_or_path)
+        hf_files = ""
+        if is_local:
+            hf_files = model_name_or_path
+        else:
+            hf_files = prepare_hf_model_weigths(model_name_or_path)
         convert_weights(hf_files, storage_folder, dtype, model)
         file = open(done_file, 'w')
         file.close()


### PR DESCRIPTION
See the issue in https://github.com/LLMServe/DistServe/issues/10
change the downloader.py and converter.py to support models with local path in offline.py
referring the code in https://github.com/LLMServe/DistServe/issues/10#issuecomment-2167593556